### PR TITLE
-Wall で警告が出ないようにした．

### DIFF
--- a/include/tdzdd/util/MessageHandler.hpp
+++ b/include/tdzdd/util/MessageHandler.hpp
@@ -142,7 +142,7 @@ public:
     MessageHandler_& begin(std::string const& s) {
         if (!enabled) return *this;
         if (!name.empty()) end("aborted");
-        name = s.empty() ? "level-" + indentLevel : s;
+        name = s.empty() ? "level-" + std::to_string(indentLevel) : s;
         indent = indentLevel * INDENT_SIZE;
         *this << "\n" << capitalize(name);
         indent = ++indentLevel * INDENT_SIZE;


### PR DESCRIPTION
下の警告が出ていましたが，直しました．
TdZdd/include/tdzdd/util/MessageHandler.hpp:145:37: warning: adding 'int' to a string
      does not append to the string [-Wstring-plus-int]
        name = s.empty() ? "level-" + indentLevel : s;