### PR TITLE
Fix typo in PodArrayDdSpec.equalTo

### DIFF
--- a/include/tdzdd/DdSpec.hpp
+++ b/include/tdzdd/DdSpec.hpp
@@ -467,7 +467,7 @@ public:
 
     bool equalTo(State const* s1, State const* s2) const {
         Word const* pa = reinterpret_cast<Word const*>(s1);
-        Word const* qa = reinterpret_cast<Word const*>(s1);
+        Word const* qa = reinterpret_cast<Word const*>(s2);
         Word const* pz = pa + dataWords;
         while (pa != pz) {
             if (*pa++ != *qa++) return false;


### PR DESCRIPTION
fix to properly compare pointers to a POD type.

I have checked this commit passes the tests at `apps/test` in my environment (Ubuntu 18.04).
Besides, the unit tests in `apps/test` do not seem to detect this typo.