### PR TITLE
Suppress 'warning: NOMINMAX redefined'

### DIFF
--- a/include/tdzdd/util/ResourceUsage.hpp
+++ b/include/tdzdd/util/ResourceUsage.hpp
@@ -34,6 +34,7 @@
 #ifndef _WIN32
 #include <sys/resource.h>
 #else
+#undef NOMINMAX
 #define NOMINMAX
 #include <windows.h>
 #include <psapi.h>


### PR DESCRIPTION
In a Windows/MinGW-w64 environment, the NOMINMAX macro has already been defined and the warning occurs.
So, to suppress it, adding "#undef NOMINMAX" is needed.
Of course, this does not affect an environment where NOMINMAX is undefined.
