### PR TITLE
Check self assignment to suppress a warning

### DIFF
--- a/include/tdzdd/util/MyVector.hpp
+++ b/include/tdzdd/util/MyVector.hpp
@@ -52,9 +52,11 @@ class MyVector {
     }
 
     void moveElement(T& from, T& to) {
-        //new (&to) T(std::move(from));
-        new (&to) T(from);
-        from.~T();
+        if (&from != &to) {
+            //new (&to) T(std::move(from));
+            new (&to) T(from);
+            from.~T();
+        }
     }
 
 public:


### PR DESCRIPTION
Newer g++ (for example, 12.4.0) outputs a warning when using MyVector.

This commit suppresses the warning by checking the self assignment in the moveElement function.

To confirm the warning message, please see the following code.
https://github.com/junkawahara/tdzdd_pr
